### PR TITLE
Changed to use specification as an array to allow ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,21 @@ let heading = [
   ['a2', 'b2', 'c2'] // <-- It can be only values
 ];
 
-//Here you specify the export structure
-var specification = {
-  customer_name: { // <- the key should match the actual data key
+//Here you specify the export structure - the order of the array is how the columns are added to excel
+var specification = [
+  {
+    propertyName:  'customer_name',// <- the key should match the actual data key
     displayName: 'Customer', // <- Here you specify the column header
     headerStyle: styles.headerDark, // <- Header style
     cellStyle: function(value, row) { // <- style renderer function
       // if the status is 1 then color in green else color in red
       // Notice how we use another cell value to style the current one
-      return (row.status_id == 1) ? styles.cellGreen : {fill: {fgColor: {rgb: 'FFFF0000'}}}; // <- Inline cell style is possible 
+      return (row.status_id == 1) ? styles.cellGreen : {fill: {fgColor: {rgb: 'FFFF0000'}}}; // <- Inline cell style is possible
     },
     width: 120 // <- width in pixels
   },
-  status_id: {
+  {
+    propertyName:  'status_id',
     displayName: 'Status',
     headerStyle: styles.headerDark,
     cellFormat: function(value, row) { // <- Renderer function, you can access also any row.property
@@ -72,13 +74,14 @@ var specification = {
     },
     width: '10' // <- width in chars (when the number is passed as string)
   },
-  note: {
+  {
+    propertyName:  'note',
     displayName: 'Description',
     headerStyle: styles.headerDark,
     cellStyle: styles.cellPink, // <- Cell style
     width: 220 // <- width in pixels
   }
-}
+]
 
 // The data set should have the following shape (Array of Objects)
 // The order of the keys is irrelevant, it is also irrelevant if the

--- a/index.js
+++ b/index.js
@@ -46,16 +46,20 @@ module.exports = {
       dataset.forEach(record => {
         let row = [];
         for (let col in specification) {
-          let cell_value = record[col];
+          if(!specification[col].propertyName){
+            throw 'Provide propertyName in specification';
+          }
+
+          let cell_value = record[specification[col].propertyName];
 
           if(specification[col].cellFormat && typeof specification[col].cellFormat == 'function') {
-            cell_value = specification[col].cellFormat(record[col], record);
+            cell_value = specification[col].cellFormat(cell_value, record, col);
           }
 
           if(specification[col].cellStyle && typeof specification[col].cellStyle == 'function') {
             cell_value = {
               value: cell_value,
-              style: specification[col].cellStyle(record[col], record)
+              style: specification[col].cellStyle(cell_value, record, col)
             };
           } else if(specification[col].cellStyle) {
             cell_value = {


### PR DESCRIPTION
I had a need to control the order of data and the columns they appeared within. The old code only appeared to allow me to handle this by using specific property names, which were then looped over. 

I changed the specification from a plain object to an array, so the ordering can be controlled and the array sorted prior to outputting to excel. I also added the column number to the cellStyle and cellFormat function handlers, so you know what column and row you are handling.
