### PR TITLE
Enable strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+"use strict";
 const excel = require('./lib/excel')
 
 let buildExport = params => {


### PR DESCRIPTION
With Node version 4.4.5 unless strict mode is on , it will not work and fail with the below error : 

let buildExport = params => {
^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode