### PR TITLE
Add formatting of numbers and dates using numFmt

### DIFF
--- a/lib/excel.js
+++ b/lib/excel.js
@@ -31,10 +31,24 @@ function sheet_from_array_of_arrays(data, merges) {
       if(cell.v === null) continue;
       let cell_ref = XLSX.utils.encode_cell({c:C,r:R});
 
-      if(typeof cell.v === 'number') cell.t = 'n';
+      if(typeof cell.v === 'number') {
+        cell.t = 'n';
+        if(data[R][C] && typeof data[R][C] === 'object'
+          && data[R][C].style && typeof data[R][C].style === 'object'
+          && data[R][C].style.numFmt) {
+          cell.z = data[R][C].style.numFmt;
+        }
+      }
       else if(typeof cell.v === 'boolean') cell.t = 'b';
       else if(cell.v instanceof Date) {
-        cell.t = 'n'; cell.z = XLSX.SSF._table[14];
+        cell.t = 'n';
+        if(data[R][C] && typeof data[R][C] === 'object'
+           && data[R][C].style && typeof data[R][C].style === 'object'
+           && data[R][C].style.numFmt) {
+          cell.z = data[R][C].style.numFmt;
+        } else {
+          cell.z = XLSX.SSF._table[14];
+        }
         cell.v = datenum(cell.v);
       }
       else cell.t = 's';


### PR DESCRIPTION
I realized that the format of the dates was hardcoded to 'm/d/yy' as opposed to being controlled by the numFmt style from https://github.com/protobi/js-xlsx#cell-styles.

In case of numbers and dates, when numFmt is present in the user defined styles, I apply it to the cell. I left the 'm/d/yy' as the default when numFmt is missing.