### PR TITLE
Pass write options to XLSX library

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const excel = require('./lib/excel')
 
-let buildExport = params => {
+let buildExport = (params, options) => {
   if (!(params instanceof Array)) throw 'buildExport expects an array'
 
   let sheets = []
@@ -81,7 +81,7 @@ let buildExport = params => {
 
   })
 
-  return excel.build(sheets)
+  return excel.build(sheets, options)
 
 }
 

--- a/lib/excel.js
+++ b/lib/excel.js
@@ -92,12 +92,12 @@ module.exports = {
       return {name: name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: true})};
     });
   },
-  build: function(array) {
-    let defaults = {
+  build: function(array, options) {
+    let writeOptions = Object.assign({
       bookType:'xlsx',
       bookSST: false,
       type:'binary'
-    };
+    }, options);
     let wb = new Workbook();
     array.forEach(function(worksheet) {
       let name = worksheet.name || 'Sheet';
@@ -111,7 +111,7 @@ module.exports = {
 
     });
 
-    let data = XLSX.write(wb, defaults);
+    let data = XLSX.write(wb, writeOptions);
     if(!data) return false;
     let buffer = new Buffer(data, 'binary');
     return buffer;


### PR DESCRIPTION
This PR adds the ability to give an `options` object as a second argument to `buildExcel`, which gets merged with some defaults and forwarded to the `write` call of the `XLSX` library.

Mostly, this is useful for setting the `bookSST` option to `true` in cases where the extra processing time and memory are worth the trade off for a smaller file size.